### PR TITLE
Update PicoCalc Terminal to version 0.2, add menu functionality, and …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if (EXISTS ${picoVscode})
 endif()
 # ====================================================================================
 set(PICO_BOARD pimoroni_pico_plus2_w_rp2350 CACHE STRING "Board type")
-set(PICOCALC_TERMINAL_VERSION "0.1" CACHE STRING "PicoCalc Terminal version")
+set(PICOCALC_TERMINAL_VERSION "0.2" CACHE STRING "PicoCalc Terminal version")
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)
@@ -52,6 +52,8 @@ add_executable(picocalc-terminal
     modules/picocalc-text-starter/drivers/picocalc.c
     modules/picocalc-text-starter/drivers/southbridge.c
     main.c
+    menu.c
+    terminal.c
     )
 
 pico_set_program_name(picocalc-terminal "picocalc-terminal")
@@ -84,13 +86,11 @@ configure_file(
 # Add any user requested libraries
 target_link_libraries(picocalc-terminal 
     pico_stdlib
-    pico_printf
     pico_multicore
     hardware_gpio
     hardware_i2c
     hardware_spi
     hardware_pio
-    hardware_clocks
     )
 
 pico_add_extra_outputs(picocalc-terminal)

--- a/main.c
+++ b/main.c
@@ -24,11 +24,11 @@
 // Global variables
 bool user_interrupt = false;
 
-int uart_port = 1;
-int baudrate = 115200;
-int databits = 8;
-int stopbits = 1;
-uart_parity_t parity = UART_PARITY_NONE;
+int uart_port;
+int baudrate;
+int databits;
+int stopbits;
+uart_parity_t parity;
 
 volatile bool connected = false;
 
@@ -180,8 +180,8 @@ int main()
 
         menu();
 
-        uart_set_baudrate(uart_port ? uart1 : uart0, baudrate);
-        uart_set_format(uart_port ? uart1 : uart0, databits, stopbits, parity);
+        uart_set_baudrate(SELECTED_UART, baudrate);
+        uart_set_format(SELECTED_UART, databits, stopbits, parity);
 
         terminal_printf("\033[?4264h\033[2J\033[H\033[mConnected at %s %d %d%s%d",
                  uart_port ? "GPIO" : "USB-C",

--- a/main.c
+++ b/main.c
@@ -4,12 +4,11 @@
 //
 
 #include <stdio.h>
+#include <string.h>
+
 #include "pico/stdlib.h"
 #include "pico/multicore.h"
-#include "pico/stdio/driver.h"
-#include "hardware/structs/uart.h"
-#include "hardware/uart.h"
-#include "version.h"
+
 #include <drivers/picocalc.h>
 #include <drivers/audio.h>
 #include <drivers/display.h>
@@ -18,139 +17,43 @@
 #include <drivers/lcd.h>
 #include <drivers/southbridge.h>
 
-bool user_interrupt = false;
-bool power_off_requested = false;
+#include "version.h"
+#include "terminal.h"
+#include "menu.h"
 
-int uart_port = 0;
+// Global variables
+bool user_interrupt = false;
+
+int uart_port = 1;
 int baudrate = 115200;
 int databits = 8;
 int stopbits = 1;
 uart_parity_t parity = UART_PARITY_NONE;
 
-#define UART_BUFFER_SIZE 4096
+volatile bool connected = false;
 
-static volatile uint8_t rx_buffer[UART_BUFFER_SIZE];
-static volatile uint16_t rx_head = 0;
-static volatile uint16_t rx_tail = 0;
 
-typedef struct
-{
-    const char *name;
-    int value;
-} menu_value_t;
-
-typedef struct
-{
-    const char *name;
-    int *value;
-    const menu_value_t *values;
-    size_t num_values;
-    int selected;
-} menu_item_t;
-
-static const menu_value_t baudrates[] = {
-    {"1200", 1200},
-    {"2400", 2400},
-    {"4800", 4800},
-    {"9600", 9600},
-    {"19200", 19200},
-    {"38400", 38400},
-    {"57600", 57600},
-    {"115200", 115200},
-};
-
-static const menu_value_t uart_ports[] = {
-    {"USB-C", 0},
-    {"GPIO", 1},
-};
-
-static menu_item_t menu_items[] = {
-    {"Port", &uart_port, uart_ports, sizeof(uart_ports) / sizeof(uart_ports[0]), 0},
-    {"Baud Rate", &baudrate, baudrates, sizeof(baudrates) / sizeof(baudrates[0]), 7},
-};
+//
+// Process a single character from the serial input
+// to be displayed on the screen
+//
 
 void process_one_char(void)
 {
-    if (rx_head != rx_tail)
+    if (serial_char_available())
     {
-        char ch = rx_buffer[rx_tail];
-        rx_tail = (rx_tail + 1) & (UART_BUFFER_SIZE - 1);
-
-        // Process the character
-        display_emit(ch);
-    }
-}
-
-void serial_putc(char ch)
-{
-    uart_putc_raw(uart_port ? uart1 : uart0, ch);
-}
-
-void serial_puts(const char *str)
-{
-    while (*str)
-    {
-        uart_putc_raw(uart_port ? uart1 : uart0, *str++);
-    }
-}
-
-void menu(void)
-{
-    int row = 5;
-    for (size_t i = 0; i < sizeof(menu_items) / sizeof(menu_items[0]); i++)
-    {
-        printf("\033[%d;0H%s: \033[%d;20H\033[%dm%6s\033[0m\n", row++, menu_items[i].name, row, i > 0 ? 0 : 7, menu_items[i].values[menu_items[i].selected].name);
-    }
-
-    row += 2;
-    printf("\033[%d;0HPress up, down to select, left, right to change,\nEnter to connect\n", row++);
-    printf("GP4 - TX, GP5 - RX\n", row++);
-
-    char ch = 0;
-    int item = 0;
-    while (ch != '\n' && ch != '\r')
-    {
-        ch = getchar();
-        if (ch == KEY_LEFT)
+        char ch = serial_getchar();
+        if (ch)
         {
-            // Decrease value
-            if (menu_items[item].selected > 0)
-            {
-                *menu_items[item].value = menu_items[item].values[--menu_items[item].selected].value;
-                printf("\033[%d;20H\033[7m%6s\033[0m", 6 + item, menu_items[item].values[menu_items[item].selected].name);
-            }
-        }
-        else if (ch == KEY_RIGHT)
-        {
-            // Increase value
-            if (menu_items[item].selected < menu_items[item].num_values - 1)
-            {
-                *menu_items[item].value = menu_items[item].values[++menu_items[item].selected].value;
-                printf("\033[%d;20H\033[7m%6s\033[0m", 6 + item, menu_items[item].values[menu_items[item].selected].name);
-            }
-        }
-        else if (ch == KEY_UP)
-        {
-            // Previous item
-            if (item > 0)
-            {
-                printf("\033[%d;20H%6s", 6 + item, menu_items[item].values[menu_items[item].selected].name);
-                item--;
-                printf("\033[%d;20H\033[7m%6s\033[0m", 6 + item, menu_items[item].values[menu_items[item].selected].name);
-            }
-        }
-        else if (ch == KEY_DOWN)
-        {
-            // Next item
-            if (item < (int)(sizeof(menu_items) / sizeof(menu_items[0])) - 1)
-            {
-                printf("\033[%d;20H%6s", 6 + item, menu_items[item].values[menu_items[item].selected].name);
-                item++;
-                printf("\033[%d;20H\033[7m%6s\033[0m", 6 + item, menu_items[item].values[menu_items[item].selected].name);
-            }
+            // Process the character
+            display_emit(ch);
         }
     }
 }
+
+//
+// Callbacks for display
+//
 
 void report(const char *message)
 {
@@ -165,94 +68,134 @@ void bell(void)
     audio_play_sound_blocking(PITCH_A4, PITCH_A4, NOTE_SIXTEENTH);
 }
 
+
+//
+// System Initialization
+//  
+
 void init(void)
 {
     sb_init();
     audio_init();
+    display_init();
+    keyboard_init();
+    terminal_init();
 
-    display_init(NULL, NULL);
-    lcd_set_font(&font_5x10); // 64 columns
     display_set_bell_callback(bell);
     display_set_report_callback(report);
-
-    keyboard_init(picocalc_chars_available_notify);
-
-    stdio_set_driver_enabled(&picocalc_stdio_driver, true);
-    stdio_set_translate_crlf(&picocalc_stdio_driver, true);
 
     // UART0
     // Set the TX and RX pins by using the function select on the GPIO
     // Set datasheet for more information on function select
     gpio_set_function(0, GPIO_FUNC_UART);
     gpio_set_function(1, GPIO_FUNC_UART);
+
+    // Set UART flow control CTS/RTS, we don't want these, so turn them off
+    uart_set_hw_flow(uart0, false, false);
+
+    // Turn on FIFO's
+    uart_set_fifo_enabled(uart0, true);
+
+    // Disable interrupts
+    uart_set_irqs_enabled(uart0, false, false);
+
+    // Disable CR/LF translation
+    uart_set_translate_crlf(uart0, false);
+
+    // Initialize UART0
+    uart_init(uart0, baudrate);
+
+    // UART1
+    // Set the TX and RX pins by using the function select on the GPIO
+    // Set datasheet for more information on function select
     gpio_set_function(4, GPIO_FUNC_UART);
     gpio_set_function(5, GPIO_FUNC_UART);
 
     // Set UART flow control CTS/RTS, we don't want these, so turn them off
-    uart_set_hw_flow(uart0, false, false);
     uart_set_hw_flow(uart1, false, false);
 
     // Turn on FIFO's
-    uart_set_fifo_enabled(uart0, true);
     uart_set_fifo_enabled(uart1, true);
 
     // Disable interrupts
-    uart_set_irqs_enabled(uart0, false, false);
     uart_set_irqs_enabled(uart1, false, false);
+
+    // Disable CR/LF translation
+    uart_set_translate_crlf(uart1, false);
+
+    // Initialize UART1
+    uart_init(uart1, baudrate);
 }
 
-void main_core1()
-{
-    char ch;
 
+//
+// Core 1 entry point: Poll keyboard in background
+//
+
+void core1_entry()
+{
     while (1)
     {
-        // Main loop for core 1
-
-        while (!(uart_get_hw(uart_port ? uart1 : uart0)->fr & UART_UARTFR_RXFE_BITS))
+        if (connected)
         {
-            ch = uart_get_hw(uart_port ? uart1 : uart0)->dr & 0x7F;
-
-            uint16_t next_head = (rx_head + 1) & (UART_BUFFER_SIZE - 1);
-            rx_buffer[rx_head] = ch;
-            rx_head = next_head;
+            keyboard_poll();
+            sleep_ms(100);
         }
-
-        tight_loop_contents();
     }
 }
 
+
+//
+// Main program loop
+//
 int main()
 {
-    stdio_init_all();
+    char buffer[32];
+
     init();
-    multicore_launch_core1(main_core1);
+    multicore_launch_core1(core1_entry);
 
     while (1)
     {
         user_interrupt = false;
 
-        printf("\033[2J\033[H\033[mTerminal %s\n", PICOCALC_TERMINAL_VERSION);
-        printf("Copyright Blair Leduc. See LICENSE for details.\n");
-        printf("Connect with USB-C port or GPIO pins, 3.3V only!\n");
-        printf("\n");
+        terminal_printf("\033[?25l\033[?4264l\033[2J\033[m\033[1;20H^");
+        terminal_printf("\033[2;18HUSB-C");
+
+        terminal_printf("\033[15;1H< TX");
+        terminal_printf("\033[16;1H< RX");
+        
+        terminal_printf("\033[19;1H< GND");
+
+        snprintf(buffer, sizeof(buffer), "Serial Terminal v%s", PICOCALC_TERMINAL_VERSION);
+        terminal_printf("\033[5;%dH\033[1m%s\033[m", (40 - strlen(buffer)) >> 1, buffer);
+
+        terminal_printf("\033[?4264h\033[24;21HUp and down to select");
+        terminal_printf("\033[25;14HLeft and right to change the setting");
+        terminal_printf("\033[26;24HEnter to connect");
+
+        terminal_printf("\033[29;15HGPIO: GP4=TX, GP5=RX, 3.3V ONLY!");
+
+        terminal_printf("\033[32;8HCopyright Blair Leduc. See LICENSE for details.\033[H\033[?4264l");
 
         menu();
 
-        uart_init(uart_port ? uart1 : uart0, baudrate);
+        uart_set_baudrate(uart_port ? uart1 : uart0, baudrate);
         uart_set_format(uart_port ? uart1 : uart0, databits, stopbits, parity);
 
-        printf("\033[2J\033[H\033[mConnected at %s %d %d%s%d\n",
-               uart_port ? "GPIO" : "USB-C",
-               baudrate,
-               databits,
-               (parity == UART_PARITY_NONE)
-                   ? "N"
-               : (parity == UART_PARITY_EVEN)
-                   ? "E"
-                   : "O",
-               stopbits);
-        printf("Press [Brk] to change.\n\n");
+        terminal_printf("\033[?4264h\033[2J\033[H\033[mConnected at %s %d %d%s%d",
+                 uart_port ? "GPIO" : "USB-C",
+                 baudrate,
+                 databits,
+                 (parity == UART_PARITY_NONE)
+                     ? "N"
+                 : (parity == UART_PARITY_EVEN)
+                     ? "E"
+                     : "O",
+                 stopbits);
+        terminal_printf("\033[2HPress [Brk] to change.\033[4H\033[?25h");
+
+        connected = true;
 
         while (!user_interrupt)
         {
@@ -321,10 +264,8 @@ int main()
                     serial_putc(ch);
                 }
             }
-
-            tight_loop_contents();
         }
 
-        uart_deinit(uart_port ? uart1 : uart0);
+        connected = false;
     }
 }

--- a/menu.c
+++ b/menu.c
@@ -10,6 +10,39 @@
 #include "terminal.h"
 #include "menu.h"
 
+static const menu_value_t uart_ports[] = {
+    {"USB-C", 0},
+    {"GPIO", 1},
+};
+
+static const menu_value_t baudrates[] = {
+    {"1200", 1200},
+    {"2400", 2400},
+    {"4800", 4800},
+    {"9600", 9600},
+    {"19200", 19200},
+    {"38400", 38400},
+    {"57600", 57600},
+    {"115200", 115200},
+    {"230400", 230400},
+};
+
+static const menu_value_t databits_options[] = {
+    {"7", 7},
+    {"8", 8},
+};
+
+static const menu_value_t parity_options[] = {
+    {"N", UART_PARITY_NONE},
+    {"E", UART_PARITY_EVEN},
+    {"O", UART_PARITY_ODD},
+};
+
+static const menu_value_t stopbits_options[] = {
+    {"1", 1},
+    {"2", 2},
+};
+
 static menu_item_t menu_items[] = {
     {"Port", &uart_port, uart_ports, sizeof(uart_ports) / sizeof(uart_ports[0]), 1},
     {"Baud Rate", &baudrate, baudrates, sizeof(baudrates) / sizeof(baudrates[0]), 7},
@@ -26,6 +59,7 @@ void menu(void)
         terminal_printf("\033[%d;10H%s: \033[%d;24H\033[%dm%6s\033[m",
                row, menu_items[i].name,
                row, i > 0 ? 0 : 4, menu_items[i].values[menu_items[i].selected].name);
+        *menu_items[i].value = menu_items[i].values[menu_items[i].selected].value;
         row += 2;
     }
 

--- a/menu.c
+++ b/menu.c
@@ -1,0 +1,76 @@
+//
+//  PicoCalc Terminal
+//  Copyright Blair leduc. See LICENSE for details.
+//
+
+#include <stdio.h>
+
+#include <drivers/keyboard.h>
+
+#include "terminal.h"
+#include "menu.h"
+
+static menu_item_t menu_items[] = {
+    {"Port", &uart_port, uart_ports, sizeof(uart_ports) / sizeof(uart_ports[0]), 1},
+    {"Baud Rate", &baudrate, baudrates, sizeof(baudrates) / sizeof(baudrates[0]), 7},
+    {"Data Bits", &databits, databits_options, sizeof(databits_options) / sizeof(databits_options[0]), 1},
+    {"Parity", (int *)&parity, parity_options, sizeof(parity_options) / sizeof(parity_options[0]), 0},
+    {"Stop Bits", &stopbits, stopbits_options, sizeof(stopbits_options) / sizeof(stopbits_options[0]), 0},
+};
+
+void menu(void)
+{
+    int row = 8;
+    for (size_t i = 0; i < sizeof(menu_items) / sizeof(menu_items[0]); i++)
+    {
+        terminal_printf("\033[%d;10H%s: \033[%d;24H\033[%dm%6s\033[m",
+               row, menu_items[i].name,
+               row, i > 0 ? 0 : 4, menu_items[i].values[menu_items[i].selected].name);
+        row += 2;
+    }
+
+    char ch = 0;
+    int item = 0;
+    while (ch != '\n' && ch != '\r')
+    {
+        ch = terminal_getchar();
+        if (ch == KEY_LEFT)
+        {
+            // Decrease value
+            if (menu_items[item].selected > 0)
+            {
+                *menu_items[item].value = menu_items[item].values[--menu_items[item].selected].value;
+                terminal_printf("\033[%d;24H\033[4m%6s\033[m", 8 + item * 2, menu_items[item].values[menu_items[item].selected].name);
+            }
+        }
+        else if (ch == KEY_RIGHT)
+        {
+            // Increase value
+            if (menu_items[item].selected < menu_items[item].num_values - 1)
+            {
+                *menu_items[item].value = menu_items[item].values[++menu_items[item].selected].value;
+                terminal_printf("\033[%d;24H\033[4m%6s\033[m", 8 + item * 2, menu_items[item].values[menu_items[item].selected].name);
+            }
+        }
+        else if (ch == KEY_UP)
+        {
+            // Previous item
+            if (item > 0)
+            {
+                terminal_printf("\033[%d;24H%6s", 8 + item * 2, menu_items[item].values[menu_items[item].selected].name);
+                item--;
+                terminal_printf("\033[%d;24H\033[4m%6s\033[m", 8 + item * 2, menu_items[item].values[menu_items[item].selected].name);
+            }
+        }
+        else if (ch == KEY_DOWN)
+        {
+            // Next item
+            if (item < (int)(sizeof(menu_items) / sizeof(menu_items[0])) - 1)
+            {
+                terminal_printf("\033[%d;24H%6s", 8 + item * 2, menu_items[item].values[menu_items[item].selected].name);
+                item++;
+                terminal_printf("\033[%d;24H\033[4m%6s\033[m", 8 + item * 2, menu_items[item].values[menu_items[item].selected].name);
+            }
+        }
+    }
+}

--- a/menu.h
+++ b/menu.h
@@ -1,0 +1,57 @@
+//
+//  PicoCalc Terminal
+//  Copyright Blair leduc. See LICENSE for details.
+//
+
+#pragma once
+
+typedef struct
+{
+    const char *name;
+    int value;
+} menu_value_t;
+
+typedef struct
+{
+    const char *name;
+    int *value;
+    const menu_value_t *values;
+    size_t num_values;
+    int selected;
+} menu_item_t;
+
+static const menu_value_t uart_ports[] = {
+    {"USB-C", 0},
+    {"GPIO", 1},
+};
+
+static const menu_value_t baudrates[] = {
+    {"1200", 1200},
+    {"2400", 2400},
+    {"4800", 4800},
+    {"9600", 9600},
+    {"19200", 19200},
+    {"38400", 38400},
+    {"57600", 57600},
+    {"115200", 115200},
+    {"230400", 230400},
+};
+
+static const menu_value_t databits_options[] = {
+    {"7", 7},
+    {"8", 8},
+};
+
+static const menu_value_t parity_options[] = {
+    {"N", UART_PARITY_NONE},
+    {"E", UART_PARITY_EVEN},
+    {"O", UART_PARITY_ODD},
+};
+
+static const menu_value_t stopbits_options[] = {
+    {"1", 1},
+    {"2", 2},
+};
+
+// Function Prototypes
+void menu(void);

--- a/menu.h
+++ b/menu.h
@@ -20,38 +20,5 @@ typedef struct
     int selected;
 } menu_item_t;
 
-static const menu_value_t uart_ports[] = {
-    {"USB-C", 0},
-    {"GPIO", 1},
-};
-
-static const menu_value_t baudrates[] = {
-    {"1200", 1200},
-    {"2400", 2400},
-    {"4800", 4800},
-    {"9600", 9600},
-    {"19200", 19200},
-    {"38400", 38400},
-    {"57600", 57600},
-    {"115200", 115200},
-    {"230400", 230400},
-};
-
-static const menu_value_t databits_options[] = {
-    {"7", 7},
-    {"8", 8},
-};
-
-static const menu_value_t parity_options[] = {
-    {"N", UART_PARITY_NONE},
-    {"E", UART_PARITY_EVEN},
-    {"O", UART_PARITY_ODD},
-};
-
-static const menu_value_t stopbits_options[] = {
-    {"1", 1},
-    {"2", 2},
-};
-
 // Function Prototypes
 void menu(void);

--- a/terminal.c
+++ b/terminal.c
@@ -29,9 +29,9 @@ bool repeating_timer_callback(struct repeating_timer *t)
 
     if (connected)
     {
-        while (!(uart_get_hw(uart_port ? uart1 : uart0)->fr & UART_UARTFR_RXFE_BITS))
+        while (!(uart_get_hw(SELECTED_UART)->fr & UART_UARTFR_RXFE_BITS))
         {
-            ch = uart_get_hw(uart_port ? uart1 : uart0)->dr & 0xFF;
+            ch = uart_get_hw(SELECTED_UART)->dr & 0xFF;
             if (ch)
             {
                 serial_addchar(ch);
@@ -84,7 +84,7 @@ bool serial_char_available(void)
 // 
 
 void terminal_printf(const char *fmt, ...) {
-    char buf[256]; // Adjust size as needed
+    char buf[TERMINAL_PRINTF_BUFFER_SIZE];
     va_list args;
     va_start(args, fmt);
     int len = vsnprintf(buf, sizeof(buf), fmt, args);
@@ -112,14 +112,14 @@ char terminal_getchar() {
 
 void serial_putc(char ch)
 {
-    uart_putc_raw(uart_port ? uart1 : uart0, ch);
+    uart_putc_raw(SELECTED_UART, ch);
 }
 
 void serial_puts(const char *str)
 {
     while (*str)
     {
-        uart_putc_raw(uart_port ? uart1 : uart0, *str++);
+        uart_putc_raw(SELECTED_UART, *str++);
     }
 }
 

--- a/terminal.c
+++ b/terminal.c
@@ -1,0 +1,134 @@
+//
+//  PicoCalc Terminal
+//  Copyright Blair leduc. See LICENSE for details.
+//
+
+#include <stdio.h>
+#include <stdarg.h>
+
+#include "pico/stdio/driver.h"
+#include "pico/stdlib.h"
+#include "hardware/structs/uart.h"
+#include "hardware/timer.h"
+#include "hardware/uart.h"
+
+#include "drivers/display.h"
+#include "drivers/keyboard.h"
+
+#include "terminal.h"
+
+static struct repeating_timer timer;
+
+//
+// Monitor the UART for incoming data
+//
+
+bool repeating_timer_callback(struct repeating_timer *t)
+{
+    char ch;
+
+    if (connected)
+    {
+        while (!(uart_get_hw(uart_port ? uart1 : uart0)->fr & UART_UARTFR_RXFE_BITS))
+        {
+            ch = uart_get_hw(uart_port ? uart1 : uart0)->dr & 0xFF;
+            if (ch)
+            {
+                serial_addchar(ch);
+            }
+        }
+    }
+
+    return true;
+}
+
+//
+//  Serial Input Buffer
+//
+
+static volatile uint8_t serial_buffer[UART_BUFFER_SIZE];
+static volatile uint32_t serial_head = 0;
+static volatile uint32_t serial_tail = 0;
+
+void serial_addchar(char ch)
+{
+    uint32_t next_head = (serial_head + 1) & (UART_BUFFER_SIZE - 1);
+    if (next_head != serial_tail) // only add if buffer is not full
+    {
+        serial_buffer[serial_head] = ch;
+        serial_head = next_head;
+    }
+}
+
+char serial_getchar(void)
+{
+    if (serial_head == serial_tail) // buffer is empty
+    {
+        return 0;
+    }
+
+    char ch = serial_buffer[serial_tail];
+    serial_tail = (serial_tail + 1) & (UART_BUFFER_SIZE - 1);
+    return ch;
+}
+
+bool serial_char_available(void)
+{
+    return serial_head != serial_tail;
+}
+
+
+
+//
+//  Terminal Output
+// 
+
+void terminal_printf(const char *fmt, ...) {
+    char buf[256]; // Adjust size as needed
+    va_list args;
+    va_start(args, fmt);
+    int len = vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    if (len < 0) return; // Formatting error
+
+    for (int i = 0; i < len && i < sizeof(buf); ++i) {
+        display_emit(buf[i]);
+    }
+}
+
+char terminal_getchar() {
+    while (!keyboard_key_available()) {
+        keyboard_poll();
+        sleep_ms(100);
+    }
+    return keyboard_get_key();
+}
+
+
+//
+// Serial Output
+//
+
+void serial_putc(char ch)
+{
+    uart_putc_raw(uart_port ? uart1 : uart0, ch);
+}
+
+void serial_puts(const char *str)
+{
+    while (*str)
+    {
+        uart_putc_raw(uart_port ? uart1 : uart0, *str++);
+    }
+}
+
+//
+// Terminal Initialization
+//
+
+void terminal_init(void)
+{
+    // Start a repeating timer to poll the UART for incoming data
+    add_repeating_timer_us(-UART_POLL_INTERVAL_US, repeating_timer_callback, NULL, &timer);
+}

--- a/terminal.h
+++ b/terminal.h
@@ -1,0 +1,35 @@
+//
+//  PicoCalc Terminal
+//  Copyright Blair leduc. See LICENSE for details.
+//
+
+#pragma once
+
+#include <hardware/uart.h>
+
+// Configuration
+#define UART_BUFFER_SIZE 65536   // Size of the UART queue (64K)
+#define UART_POLL_INTERVAL_US 50 // Polling interval in microseconds (good for 230400 baud and below)
+
+// UART Configuration
+extern int uart_port;
+extern int baudrate;
+extern int databits;
+extern int stopbits;
+extern uart_parity_t parity;
+
+// Connection state
+extern volatile bool connected;
+
+
+// Function prototypes
+void terminal_init(void);
+
+bool serial_char_available(void);
+char serial_getchar(void);
+void serial_addchar(char ch);
+void serial_putc(char ch);
+void serial_puts(const char *s);
+
+void terminal_printf(const char *fmt, ...);
+char terminal_getchar(void);

--- a/terminal.h
+++ b/terminal.h
@@ -10,6 +10,7 @@
 // Configuration
 #define UART_BUFFER_SIZE 65536   // Size of the UART queue (64K)
 #define UART_POLL_INTERVAL_US 50 // Polling interval in microseconds (good for 230400 baud and below)
+#define TERMINAL_PRINTF_BUFFER_SIZE 256 // Size of the buffer for terminal_printf
 
 // UART Configuration
 extern int uart_port;
@@ -21,6 +22,7 @@ extern uart_parity_t parity;
 // Connection state
 extern volatile bool connected;
 
+#define SELECTED_UART (uart_port ? uart1 : uart0)
 
 // Function prototypes
 void terminal_init(void);


### PR DESCRIPTION
This pull request refactors and modularizes the PicoCalc Terminal codebase, improving maintainability and adding new features to the serial terminal interface. The changes split menu and terminal logic into their own files, enhance serial communication handling, and expand configuration options for the terminal.

**Major refactoring and feature additions:**

*Codebase modularization and cleanup:*
- Moved menu logic out of `main.c` into new files `menu.c` and `menu.h`, and terminal logic into `terminal.c` and `terminal.h`, significantly cleaning up `main.c` and improving separation of concerns. [[1]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecR20-R56) [[2]](diffhunk://#diff-a010596682d668216a2d38c5dcbc163a735ac1b12ce1f973e9dbe6eecdfc1b90R1-R76) [[3]](diffhunk://#diff-57c3f339b379900ba3d98e0593d8ffdb78d9d190381c3533b4a29cb021488b4bR1-R57) [[4]](diffhunk://#diff-8b06e34c81ba83974deee14e455e611e3f93b91d9ec7355d7752ef80b1fce935R1-R134) [[5]](diffhunk://#diff-6dba91cc8eabcbae568134f5491121a773f7a1da4a352c3f0a6b6834ffa317d8R1-R35)
- Removed legacy UART buffer and menu code from `main.c`, replacing them with modular functions and structures.

*Expanded terminal configuration:*
- Added support for configuring additional serial parameters (data bits, parity, stop bits, and more baud rates) via the menu, making the terminal more flexible for different use cases. [[1]](diffhunk://#diff-57c3f339b379900ba3d98e0593d8ffdb78d9d190381c3533b4a29cb021488b4bR1-R57) [[2]](diffhunk://#diff-a010596682d668216a2d38c5dcbc163a735ac1b12ce1f973e9dbe6eecdfc1b90R1-R76)

*Improved serial communication handling:*
- Implemented a large circular buffer for serial input (`UART_BUFFER_SIZE` increased to 65536), and introduced a timer-based UART polling mechanism for robust and efficient serial data capture. [[1]](diffhunk://#diff-8b06e34c81ba83974deee14e455e611e3f93b91d9ec7355d7752ef80b1fce935R1-R134) [[2]](diffhunk://#diff-6dba91cc8eabcbae568134f5491121a773f7a1da4a352c3f0a6b6834ffa317d8R1-R35)
- Centralized serial input/output and terminal display functions in `terminal.c` for consistent behavior and easier maintenance.

*Enhanced user interface:*
- Updated terminal screen output to use `terminal_printf` for improved formatting and display, including clearer instructions and connection status. [[1]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecR71-R186) [[2]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecL255-R198) [[3]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecL324-R269) [[4]](diffhunk://#diff-8b06e34c81ba83974deee14e455e611e3f93b91d9ec7355d7752ef80b1fce935R1-R134) [[5]](diffhunk://#diff-a010596682d668216a2d38c5dcbc163a735ac1b12ce1f973e9dbe6eecdfc1b90R1-R76)

*Build system updates:*
- Updated `CMakeLists.txt` to include new source files (`menu.c`, `terminal.c`), remove unused libraries, and bump the terminal version to 0.2. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL27-R27) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR55-R56) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL87-L93)

These changes collectively make the PicoCalc Terminal codebase cleaner, more maintainable, and more feature-rich.…improve UART handling